### PR TITLE
Explicitly load readme as UTF-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 from deploymentutils.release import __version__
 
-with open("README.md") as readme_file:
+with open("README.md", encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
 


### PR DESCRIPTION
Windows defaults to Windows-1252 encoding which results in errors
when encountering more exotic characters during package installation